### PR TITLE
Updating shopify-api to v1.0.1

### DIFF
--- a/app/Lib/CookieHandler.php
+++ b/app/Lib/CookieHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lib;
+
+use Illuminate\Support\Facades\Cookie;
+use Shopify\Auth\OAuthCookie;
+use Shopify\Context;
+
+class CookieHandler
+{
+    public static function saveShopifyCookie(OAuthCookie $cookie)
+    {
+        Cookie::queue(
+            $cookie->getName(),
+            $cookie->getValue(),
+            $cookie->getExpire() ? ceil(($cookie->getExpire() - time()) / 60) : null,
+            '/',
+            Context::$HOST_NAME,
+            $cookie->isSecure(),
+            $cookie->isHttpOnly(),
+            false,
+            'Lax'
+        );
+
+        return true;
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -2851,16 +2851,16 @@
         },
         {
             "name": "shopify/shopify-api",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Shopify/shopify-php-api.git",
-                "reference": "a93ba91205277e6d918e4d89343fb36e44fb3301"
+                "reference": "a5238ef6b15e457d6a8c581940f6c74474914041"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Shopify/shopify-php-api/zipball/a93ba91205277e6d918e4d89343fb36e44fb3301",
-                "reference": "a93ba91205277e6d918e4d89343fb36e44fb3301",
+                "url": "https://api.github.com/repos/Shopify/shopify-php-api/zipball/a5238ef6b15e457d6a8c581940f6c74474914041",
+                "reference": "a5238ef6b15e457d6a8c581940f6c74474914041",
                 "shasum": ""
             },
             "require": {
@@ -2906,9 +2906,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Shopify/shopify-php-api/issues",
-                "source": "https://github.com/Shopify/shopify-php-api/tree/v1.0.0"
+                "source": "https://github.com/Shopify/shopify-php-api/tree/v1.0.1"
             },
-            "time": "2021-08-09T15:28:56+00:00"
+            "time": "2021-11-30T16:25:06+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -7994,5 +7994,5 @@
         "php": "^7.3 || ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,6 @@
 use App\Models\Session;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Shopify\Auth\OAuth;
@@ -65,27 +64,18 @@ Route::get('/login', function (Request $request) {
         $shop,
         '/auth/callback',
         true,
-        function (Shopify\Auth\OAuthCookie $cookie) {
-            Cookie::queue(
-                $cookie->getName(),
-                $cookie->getValue(),
-                ceil(($cookie->getExpire() - time()) / 60),
-                '/',
-                Context::$HOST_NAME,
-                $cookie->isSecure(),
-                $cookie->isHttpOnly(),
-                false,
-                'Lax'
-            );
-            return true;
-        }
+        ['App\Lib\CookieHandler', 'saveShopifyCookie'],
     );
 
     return redirect($installUrl);
 });
 
 Route::get('/auth/callback', function (Request $request) {
-    $session = OAuth::callback($request->cookie(), $request->query());
+    $session = OAuth::callback(
+        $request->cookie(),
+        $request->query(),
+        ['App\Lib\CookieHandler', 'saveShopifyCookie'],
+    );
 
     $host = $request->query('host');
     $shop = Utils::sanitizeShopDomain($request->query('shop'));


### PR DESCRIPTION
This PR is updating the dependency on `shopify/shopify-api` to v1.0.1 and ensuring we're updating the OAuth cookie after the process is completed.