### PR TITLE
Add CLA probot

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla


### PR DESCRIPTION
This PR adds the CLA probot so that we can ask external contributors to sign it before accepting their PRs.