### PR TITLE
Update team tagged for Dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       time: "00:00"
       timezone: "UTC"
     reviewers:
-      - Shopify/core-build-learn
+      - Shopify/client-libraries-atc
     labels:
       - "Composer upgrades"
     open-pull-requests-limit: 100


### PR DESCRIPTION
Updates the team responsible for dependabot reviews: `Shopify/core-build-learn` -> `Shopify/client-libraries-atc`