### PR TITLE
Fix close-external-prs workflow incorrectly closing internal PRs

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -16,25 +16,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const author = context.payload.pull_request.user.login;
-
-            try {
-              // Check if the author is a member of the Shopify organization
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'Shopify',
-                username: author
-              });
-
-              console.log(`${author} is a Shopify member`);
-              core.setOutput('is-shopify', 'true');
-            } catch (error) {
-              if (error && error.status === 404) {
-                console.log(`${author} is not a Shopify member`);
-              } else {
-                console.log(`Error checking Shopify membership for ${author}: ${error}`);
-              }
-              core.setOutput('is-shopify', 'false');
-            }
+            const association = context.payload.pull_request.author_association;
+            const isInternal = ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(association);
+            console.log(`${context.payload.pull_request.user.login} author_association: ${association}`);
+            core.setOutput('is-shopify', isInternal ? 'true' : 'false');
 
       - name: Close PR and comment
         if: steps.check-author.outputs.is-shopify == 'false'


### PR DESCRIPTION
## Summary
- The `close-external-prs` workflow was closing PRs from Shopify org members because `orgs.checkMembershipForUser` requires `read:org` scope, which the default `GITHUB_TOKEN` doesn't have
- Replaced the API call with `author_association` from the webhook payload, which is always available and correctly identifies `MEMBER`, `OWNER`, and `COLLABORATOR` authors

## Test plan
- [x] Verified the failing run logs confirm the org membership API returned 404 for a known Shopify member: https://github.com/Shopify/shopify-app-php/actions/runs/21878891669/job/63155468682
- [ ] Open a test PR from a Shopify org member account and confirm it is **not** closed
- [ ] Verify an external contributor's PR is still closed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)